### PR TITLE
Handling dynamic device changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,40 @@
 # mergeinputs
+
 for some reason theres some issues using multiple keyboards simultaneously in linux, for some applications. this is a very small utility to merge/combine keyboards in linux into one `merged input` device.
 
 ## usage
-```
+
+```plain
 mergeinputs inputeventpaths
 example to merge all keyboards: mergeinputs /dev/input/by-path/*-kbd
 ```
+
 depending on your distro you might either need the `input` group or run mergeinputs as root.
 
 ## but how does it work?
+
 leveraging the uinput module, mergeinputs is able to sit before any userspace input drivers:
 
 `/dev/input/eventx /dev/input/eventy -> mergeinputs grabs all key events -> "merged input" device -> input drivers -> userspace applications`
 
-this means any application will only see one keyboard(`merged inputs`) pressing keys, eliminating any issues multiple devices might've caused.
+this means any application will only see one keyboard (`merged inputs`) pressing keys, eliminating any issues multiple devices might've caused.
 
 ## install
+
 `make install`
 
 ## auto-start and reload on device change
+
 To start the utility on every boot, a sample systemd unit is provided:
-```
+
+```plain
 sudo cp mergeinputs.service /etc/systemd/system
 sudo systemctl enable --now mergeinputs
 ```
 
 If you want to restart mergeinputs on device changes to handle hotplugging of keyboards, use the mergeinputs-restart units:
-```
+
+```plain
 sudo cp mergeinputs-restart.* /etc/systemd/system
 sudo systemctl enable --now mergeinputs-restart.path
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ for some reason theres some issues using multiple keyboards simultaneously in li
 ## usage
 ```
 mergeinputs inputeventpaths
-example to merge all keyboards: mergeinputs /dev/input/by-id/*-kbd
+example to merge all keyboards: mergeinputs /dev/input/by-path/*-kbd
 ```
 depending on your distro you might either need the `input` group or run mergeinputs as root.
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,15 @@ this means any application will only see one keyboard(`merged inputs`) pressing 
 ## install
 `make install`
 
-## auto-start
+## auto-start and reload on device change
 To start the utility on every boot, a sample systemd unit is provided:
 ```
 sudo cp mergeinputs.service /etc/systemd/system
 sudo systemctl enable --now mergeinputs
+```
+
+If you want to restart mergeinputs on device changes to handle hotplugging of keyboards, use the mergeinputs-restart units:
+```
+sudo cp mergeinputs-restart.* /etc/systemd/system
+sudo systemctl enable --now mergeinputs-restart.path
 ```

--- a/mergeinputs-restart.path
+++ b/mergeinputs-restart.path
@@ -1,6 +1,6 @@
 [Path]
 Unit=mergeinputs-restart.service
-PathChanged=/dev/input/by-id
+PathChanged=/dev/input/by-path
 
 [Unit]
 StartLimitIntervalSec=5

--- a/mergeinputs-restart.path
+++ b/mergeinputs-restart.path
@@ -1,0 +1,6 @@
+[Path]
+Unit=mergeinputs-restart.service
+PathChanged=/dev/input/by-id
+
+[Install]
+WantedBy=multi-user.target

--- a/mergeinputs-restart.path
+++ b/mergeinputs-restart.path
@@ -2,5 +2,9 @@
 Unit=mergeinputs-restart.service
 PathChanged=/dev/input/by-id
 
+[Unit]
+StartLimitIntervalSec=5
+StartLimitBurst=20
+
 [Install]
 WantedBy=multi-user.target

--- a/mergeinputs-restart.service
+++ b/mergeinputs-restart.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=mergeinputs restarter
+After=multi-user.target
+StartLimitIntervalSec=10
+StartLimitBurst=5
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemctl restart mergeinputs.service
+
+[Install]
+WantedBy=multi-user.target

--- a/mergeinputs-restart.service
+++ b/mergeinputs-restart.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=mergeinputs restarter
 After=multi-user.target
-StartLimitIntervalSec=10
-StartLimitBurst=5
+StartLimitIntervalSec=5
+StartLimitBurst=20
 
 [Service]
 Type=oneshot

--- a/mergeinputs.service
+++ b/mergeinputs.service
@@ -2,7 +2,11 @@
 Description=Merge multiple keyboards into one input
 After=multi-user.target
 ConditionPathExistsGlob=/dev/input/by-id/*-kbd
+StartLimitIntervalSec=5
+StartLimitBurst=20
+
 [Service]
 ExecStart=/bin/sh -c '/usr/local/bin/mergeinputs /dev/input/by-id/*-kbd'
+
 [Install]
 WantedBy=multi-user.target

--- a/mergeinputs.service
+++ b/mergeinputs.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=Merge multiple keyboards into one input
 After=multi-user.target
-ConditionPathExistsGlob=/dev/input/by-id/*-kbd
+ConditionPathExistsGlob=/dev/input/by-path/*-kbd
 StartLimitIntervalSec=5
 StartLimitBurst=20
 
 [Service]
-ExecStart=/bin/sh -c '/usr/local/bin/mergeinputs /dev/input/by-id/*-kbd'
+ExecStart=/bin/sh -c '/usr/local/bin/mergeinputs /dev/input/by-path/*-kbd'
 
 [Install]
 WantedBy=multi-user.target

--- a/mergeinputs.service
+++ b/mergeinputs.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Merge multiple keyboards into one input
 After=multi-user.target
+ConditionPathExistsGlob=/dev/input/by-id/*-kbd
 [Service]
 ExecStart=/bin/sh -c '/usr/local/bin/mergeinputs /dev/input/by-id/*-kbd'
 [Install]


### PR DESCRIPTION
Hi I found a way to handle device changes (ie hotplugging of keyboards) by watching the path where mergeinputs gets its devices and restarting the service if there are any changes.

Luckily the virtual input device that mergeinputs creates gets no entry in the `by-id` subdirectory, so this seems safe and should not create loops.